### PR TITLE
Validator Key Management experiment 

### DIFF
--- a/validator_management/README.md
+++ b/validator_management/README.md
@@ -1,1 +1,3 @@
 # Validator Management in a Raspberry PI
+
+The goal of this script is to test how validator keys and slashing protection can be imported and exported between the different Eth2 CL clients

--- a/validator_management/README.md
+++ b/validator_management/README.md
@@ -2,4 +2,11 @@
 
 The goal of this script is to test how validator keys and slashing protection can be imported and exported between the different Eth2 CL clients
 To run experiments please use launcher loop file, which is the most updated one.
-You may need to change the name of the launcher files for Lodestar. 
+You may need to change the name of the launcher files for Lodestar.
+
+# Setup
+
+Please keep in mind that we have used [EthereumonARM](https://ethereum-on-arm-documentation.readthedocs.io/en/latest/kiln/kiln-testnet.html#).
+Additionally we have installed [Lodestar](https://chainsafe.github.io/lodestar/install/source/) and Grandine, which were not included in the ISO image.
+You may use the files included in this repository to reproduce the same behaviour as the experiment we have performed.
+ 

--- a/validator_management/README.md
+++ b/validator_management/README.md
@@ -1,3 +1,5 @@
 # Validator Management in a Raspberry PI
 
 The goal of this script is to test how validator keys and slashing protection can be imported and exported between the different Eth2 CL clients
+To run experiments please use launcher loop file, which is the most updated one.
+You may need to change the name of the launcher files for Lodestar. 

--- a/validator_management/grandine.service
+++ b/validator_management/grandine.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ethereum Grandine client daemon by The Ethereum Foundation
+After=network.target
+
+[Service]
+ExecStart=/home/ethereum/grandine_logs/grandine-0.2.0_beta3_arm64 --eth1-rpc-urls http://localhost:8551/ --network kiln --data-dir /home/ethereum/.grandine --jwt-secret=/etc/ethereum/kiln/jwtsecret --keystore-dir /home/ethereum/.grandine/keys --keystore-password-file /home/ethereum/.grandine/secrets
+WorkingDirectory=/home/ethereum/grandine_logs
+Restart=always
+User=ethereum
+StandardOutput=append:/home/ethereum/grandine_logs/grandine_std.log
+StandardError=append:/home/ethereum/grandine_logs/grandine_err.log
+
+
+[Install]
+WantedBy=multi-user.target

--- a/validator_management/launch_all_clients.sh
+++ b/validator_management/launch_all_clients.sh
@@ -1,6 +1,6 @@
 
-SLEEP_TIME=3840
-TWO_EPOCHS=768
+SLEEP_TIME=3840 # 10 epochs, let each client run
+TWO_EPOCHS=768 # 2 epochs, transition betwee exporting and importing slashing protection
  
 # Prysm
 

--- a/validator_management/launch_all_clients.sh
+++ b/validator_management/launch_all_clients.sh
@@ -4,60 +4,72 @@ TWO_EPOCHS=768 # 2 epochs, transition betwee exporting and importing slashing pr
  
 # Prysm
 
+echo "Prysm Client"
+
 # Import slashing protection
-validator-kl slashing-protection-history export --datadir=/home/ethereum/.pry-geth/kiln/testnet-pry --slashing-protection-export-dir=/home/ethereum/prysm_logs/prysm_slashing_protection/ | tee -a /home/ethereum/prysm_logs/slashing_protection_export.log
+echo "Prysm: Importing slashing protection..."
+
+# TODO: Import the last slashing protection from the last client executed in the first run
+# validator-kl slashing-protection-history export --datadir=/home/ethereum/.pry-geth/kiln/testnet-pry --slashing-protection-export-dir=/home/ethereum/prysm_logs/prysm_slashing_protection/ | tee -a /home/ethereum/prysm_logs/slashing_protection_export.log
 
 # Import validators (already done but simulate we do)
+echo "Prysm: Importing validators..."
 
 for d in /home/ethereum/kiln_validators/assigned_data_0_249/secrets/*; do
 	final_d=$(basename $d)
 	validator-kl accounts import --keys-dir=/home/ethereum/kiln_validators/assigned_data_0_249/keys/$final_d --account-password-file=$d --wallet-dir /home/ethereum/.pry-geth/kiln/testnet-pry --wallet-password-file=/home/ethereum/prysm_logs/wallet_password.txt | tee -a import_log.txt
 done
 
+echo "Prysm: Exporting Slashing protection...."
+
+validator-kl slashing-protection-history export --datadir=/home/ethereum/.pry-geth/kiln/testnet-pry --slashing-protection-export-dir=/home/ethereum/prysm_logs/prysm_slashing_protection/ | tee -a /home/ethereum/prysm_logs/slashing_protection_export.log
+
 
 # Run geth
+echo "Prysm: Running Geth...."
 
 sudo systemctl start geth-pry.service
 
 # Run Prysm Beacon node
-
+echo "Prysm: Running Beacon Node...."
 sudo systemctl start pry-geth-beacon.service
 
-# Run the validator node
-
+# Run the Prysm Validator node
+echo "Prysm: Running the Validator Node..."
 sudo systemctl start pry-geth-validator.service
 
 sleep $SLEEP_TIME
 
 
 # Stop the validator node
-
+echo "Prysm: Stopping the Validator Node..."
 sudo systemctl stop pry-geth-validator.service
 
 # Stop Prysm Beacon node
-
+echo "Prysm: Stopping the Beacon Node..."
 sudo systemctl stop pry-geth-beacon.service
 
 # Stop geth
-
+echo "Prysm: Stopping Geth..."
 sudo systemctl stop geth-pry.service
 
 
 # Export slashing protection
-
+echo "Prysm: Exporting Slashing protection..."
 validator-kl slashing-protection-history export --datadir=/home/ethereum/.pry-geth/kiln/testnet-pry --slashing-protection-export-dir=/home/ethereum/prysm_logs/prysm_slashing_protection/ | tee -a /home/ethereum/prysm_logs/slashing_protection_export.log
 
+echo "Prysm: Finished. Stopping for 2 epochs..."
 sleep $TWO_EPOCHS
 # ------------------------------------------------------
 
 # Lighthouse
-
+echo "Lighthouse"
 # Import slashing protection
-
+echo "Lighthouse: Importing Slashing Protection..."
 lighthouse-kl --network kiln account validator slashing-protection import ../prysm_logs/prysm_slashing_protection/slashing_protection.json --datadir=/home/ethereum/.lh-geth/kiln/testnet-lh | tee -a import.log
 
 # Import validators (already done but simulating we do)
-
+echo "Lighthouse: Importing Validators..."
 for d in /home/ethereum/kiln_validators/assigned_data_0_249/secrets/*; do
 	final_d=$(basename $d)
         lighthouse-kl --network kiln account validator import --directory /home/ethereum/kiln_validators/assigned_data_0_249/keys/$final_d --datadir=/home/ethereum/.lh-geth/kiln/testnet-lh --password-file $d --reuse-password | tee -a /home/ethereum/lighthouse_logs/import.log
@@ -65,48 +77,49 @@ done
 
 
 # Run geth
-
+echo "Lighthouse: Running Geth..."
 sudo systemctl start geth-lh.service
 
 # Run Lighthouse Beacon node
-
+echo "Lighthouse: Running the Beacon Node..."
 sudo systemctl start lh-geth-beacon.service
 
 # Run Lighthouse Validator node
-
+echo "Lighthouse: Running the Validator Node"
 sudo systemctl start lh-geth-validator.service
-
+echo "Lighthouse: Sleeping for 10 epochs"
 sleep $SLEEP_TIME
 
 
 # Stop Lighthouse Validator node
-
+echo "Lighthouse: Stopping the Validator Node..."
 sudo systemctl start lh-geth-validator.service
 
 # Stop Lighthosue Beacon node
-
+echo "Lighthouse: Stopping the Beacon Node..."
 sudo systemctl start lh-geth-beacon.service
 
 # Stop Geth
-
+echo "Lighthouse: Stopping Geth..."
 sudo systemctl start geth-lh.service
 
 # Export Slashing protection
 
-
+echo "Lighthouse: Exporting Slashing Protection..."
 lighthouse-kl account validator slashing-protection export /home/ethereum/lighthouse_logs/lighthouse_slashing_protection.json --datadir=/home/ethereum/.lh-geth/kiln/testnet-lh --network kiln
-
+echo "Lighthouse: finished. Sleeping for 2 epochs..."
 sleep $TWO_EPOCHS
 # ------------------------------------------------------------------------------
 
 # Nimbus
 
+echo "Nimbus"
 # Import slashing protection
-
+echo "Nimbus: Importing the Slahing Protection..."
 nimbus_beacon_node-kl slashingdb import /home/ethereum/lighthouse_logs/lighthouse_slashing_protection.json --data-dir=/home/ethereum/.nim-geth/kiln/testnet-nim | tee -a /home/ethereum/nimbus_logs/import.log
 
 # Import validators
-
+echo "Nimbus: Importing Validators..."
 for d in /home/ethereum/kiln_validators/assigned_data_0_249/secrets/*; do
 	final_d=$(basename $d)
 	# password=`cat $d`
@@ -116,68 +129,69 @@ done
 
 
 # Run Geth
-
+echo "Nimbus: Running Geth..."
 sudo systemctl start geth-nim.service
 
 # Run Nimbus
-
+echo "Nimbus: Running the Beacon + Validator Node"
 sudo systemctl start nim-geth.service
 
-
+echo "Nimbus: Leaving it run for 10 epochs..."
 sleep $SLEEP_TIME
 
 
 # Stop Nimbus
-
+echo "Nimbus: Stopping the Beacon + Validator Node..."
 sudo systemctl stop nim-geth.service
 
 # Stop Geth
-
+echo "Nimbus: Stopping Geth..."
 sudo systemctl stop geth-nim.service
 
 
 # Export Slashing protection
-
+echo "Nimbus: Exporting Slashing Protection..."
 nimbus_beacon_node-kl slashingdb export /home/ethereum/nimbus_logs/slashing_database.json --data-dir=/home/ethereum/.nim-geth/kiln/testnet-nim | tee -a /home/ethereum/nimbus_logs/slashing_logs.log
 
-
+echo "Nimbus: finished. Waiting 2 epochs..."
 sleep $TWO_EPOCHS
 
 # -----------------------------------------------------------------------
 
 # Teku
-
+echo "Teku"
 # Import Slashing protection
-
+echo "Teku: Importing Slashing Protection..."
 teku-kl slashing-protection import --from /home/ethereum/nimbus_logs/slashing_database.json | tee -a /home/ethereum/teku_logs/slashing_import.log
 
 # Import validators (already done, already copied keys and secrets)
 
 
 # Run Geth
-
+echo "Teku: Running Geth..."
 sudo systemctl start geth-teku.service
 
 # Run Teku
-
+echo "Teku: Running the Beacon + Validator Node..."
 sudo systemctl start teku-geth.service
-
+echo "Teku: Leaving it run for 10 epochs..."
 sleep $SLEEP_TIME
 
 # Stop Teku
-
+echo "Teku: Stopping Beacon + Validator Node..."
 sudo systemctl stop teku-geth.service
 
 
 # Stop Geth
-
+echo "Teku: Stopping Geth..."
 sudo systemctl stop geth-teku.service
 
 
 # Export Slashing Protection
-
+echo "Teku: Exporting Slashing Protection..."
 teku-kl slashing-protection export --data-path /home/ethereum/.teku-geth/kiln/datadir-teku --to /home/ethereum/teku_logs/slashing_db.json | tee -a /home/ethereum/teku_logs/slashing.log
 
+echo "Teku: finished. Waiting for 2 epochs..."
 sleep $TWO_EPOCHS
 
 

--- a/validator_management/launch_all_clients_loop.sh
+++ b/validator_management/launch_all_clients_loop.sh
@@ -4,6 +4,7 @@
 
 SLEEP_TIME=3840 # 10 epochs, let each client run
 TWO_EPOCHS=768 # 2 epochs, transition between stopping validators in one client and running them in the next client
+TWO_EPOCHS=1 # now lets try not waiting
 while true
 do
 echo "Sleeping 768 for security..."

--- a/validator_management/launch_all_clients_loop.sh
+++ b/validator_management/launch_all_clients_loop.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
 # set -e
+
 SLEEP_TIME=3840 # 10 epochs, let each client run
-SLEEP_TIME=1500
-# TWO_EPOCHS=768 # 2 epochs, transition between stopping validators in one client and running them in the next client
-TWO_EPOCHS=1500
+TWO_EPOCHS=768 # 2 epochs, transition between stopping validators in one client and running them in the next client
+while true
+do
+echo "Sleeping 768 for security..."
+sleep 768
 # Prysm
 
 echo "Prysm Client"
@@ -14,7 +17,7 @@ echo "Prysm: Importing slashing protection..."
 
 # TODO: Import the last slashing protection from the last client executed in the first run
 
-validator-kl slashing-protection-history import --datadir=/home/ethereum/.pry-geth/kiln/testnet-pry --slashing-protection-json-file=/home/ethereum/lodestar_logs/lodestar/kiln/devnets/kiln-data/slashing_protection.json | tee -a /home/ethereum/prysm_logs/import_slashing.log
+validator-kl slashing-protection-history import --datadir=/home/ethereum/.pry-geth/kiln/testnet-pry --slashing-protection-json-file=/home/ethereum/lodestar_logs/slashing_protection.json
 
 # Import validators (already done)
 
@@ -59,7 +62,7 @@ echo "Prysm: Stopping Geth..."
 # Export slashing protection
 rm /home/ethereum/prysm_logs/prysm_slashing_protection/*
 echo "Prysm: Exporting Slashing protection..."
-validator-kl slashing-protection-history export --datadir=/home/ethereum/.pry-geth/kiln/testnet-pry --slashing-protection-export-dir=/home/ethereum/prysm_logs/prysm_slashing_protection/ | tee -a /home/ethereum/prysm_logs/slashing_protection_export.log
+validator-kl slashing-protection-history export --datadir=/home/ethereum/.pry-geth/kiln/testnet-pry --slashing-protection-export-dir=/home/ethereum/prysm_logs/prysm_slashing_protection/
 
 echo "Prysm: Finished. Stopping for 2 epochs..."
 sleep $TWO_EPOCHS
@@ -70,7 +73,7 @@ sleep $TWO_EPOCHS
 echo "Lighthouse"
 # Import slashing protection
 echo "Lighthouse: Importing Slashing Protection..."
-lighthouse-kl --network kiln account validator slashing-protection import /home/ethereum/prysm_logs/prysm_slashing_protection/slashing_protection.json --datadir=/home/ethereum/.lh-geth/kiln/testnet-lh | tee -a import.log
+lighthouse-kl --network kiln account validator slashing-protection import /home/ethereum/prysm_logs/prysm_slashing_protection/slashing_protection.json --datadir=/home/ethereum/.lh-geth/kiln/testnet-lh
 
 # Import validators (already done but simulating we do)
 # echo "Lighthouse: Importing Validators..."
@@ -108,7 +111,7 @@ echo "Lighthouse: Stopping Geth..."
 # sudo systemctl stop geth-lh.service
 
 # Export Slashing protection
-rm /home/ethereum/lighthouse_logs/lighthouse_slashing_protection.json
+rm /home/ethereum/lighthouse_logs/slashing_protection.json
 echo "Lighthouse: Exporting Slashing Protection..."
 lighthouse-kl account validator slashing-protection export /home/ethereum/lighthouse_logs/slashing_protection.json --datadir=/home/ethereum/.lh-geth/kiln/testnet-lh --network kiln
 echo "Lighthouse: finished. Sleeping for 2 epochs..."
@@ -120,7 +123,7 @@ sleep $TWO_EPOCHS
 echo "Nimbus"
 # Import slashing protection
 echo "Nimbus: Importing the Slahing Protection..."
-nimbus_beacon_node-kl slashingdb import /home/ethereum/lighthouse_logs/slashing_protection.json --data-dir=/home/ethereum/.nim-geth/kiln/testnet-nim | tee -a /home/ethereum/nimbus_logs/import.log
+/home/ethereum/nimbus-eth2_Linux_arm64v8_22.6.1_2444e994/build/nimbus_beacon_node slashingdb import /home/ethereum/lighthouse_logs/slashing_protection.json --data-dir=/home/ethereum/.nim-geth/kiln/testnet-nim
 
 # Import validators
 # echo "Nimbus: Importing Validators..."
@@ -154,9 +157,9 @@ echo "Nimbus: Stopping Geth..."
 
 
 # Export Slashing protection
-rm /home/ethereum/nimbus_logs/slashing_db.json
+rm /home/ethereum/nimbus_logs/slashing_protection.json
 echo "Nimbus: Exporting Slashing Protection..."
-nimbus_beacon_node-kl slashingdb export /home/ethereum/nimbus_logs/slashing_protection.json --data-dir=/home/ethereum/.nim-geth/kiln/testnet-nim | tee -a /home/ethereum/nimbus_logs/slashing_logs.log
+/home/ethereum/nimbus-eth2_Linux_arm64v8_22.6.1_2444e994/build/nimbus_beacon_node slashingdb export /home/ethereum/nimbus_logs/slashing_protection.json --data-dir=/home/ethereum/.nim-geth/kiln/testnet-nim
 
 echo "Nimbus: finished. Waiting 2 epochs..."
 sleep $TWO_EPOCHS
@@ -167,7 +170,7 @@ sleep $TWO_EPOCHS
 echo "Teku"
 # Import Slashing protection
 echo "Teku: Importing Slashing Protection..."
-teku-kl slashing-protection import --from /home/ethereum/nimbus_logs/slashing_protection.json --data-path /home/ethereum/.teku-geth/kiln/datadir-teku | tee -a /home/ethereum/teku_logs/slashing_import.log
+teku-kl slashing-protection import --from /home/ethereum/nimbus_logs/slashing_protection.json --data-path /home/ethereum/.teku-geth/kiln/datadir-teku
 
 # Import validators (already done, already copied keys and secrets)
 
@@ -194,9 +197,9 @@ echo "Teku: Stopping Geth..."
 
 
 # Export Slashing Protection
-rm /home/ethereum/teku_logs/slashing_db.json
+rm /home/ethereum/teku_logs/slashing_protection.json
 echo "Teku: Exporting Slashing Protection..."
-teku-kl slashing-protection export --data-path /home/ethereum/.teku-geth/kiln/datadir-teku --to /home/ethereum/teku_logs/slashing_protection.json | tee -a /home/ethereum/teku_logs/slashing.log
+teku-kl slashing-protection export --data-path /home/ethereum/.teku-geth/kiln/datadir-teku --to /home/ethereum/teku_logs/slashing_protection.json
 
 echo "Teku: finished. Waiting for 2 epochs..."
 sleep $TWO_EPOCHS
@@ -215,7 +218,7 @@ cd /home/ethereum/grandine_logs
 
 echo "Grandine: Importing slashing protection..."
 
-./grandine-0.2.0_beta3_arm64 --network kiln --data-dir /home/ethereum/.grandine interchange import /home/ethereum/teku_logs/slashing_protection.json | tee -a slashing_import.log
+./grandine-0.2.0_beta3_arm64 --network kiln --data-dir /home/ethereum/.grandine interchange import /home/ethereum/teku_logs/slashing_protection.json
 
 # Import validators (already imported)
 
@@ -244,18 +247,13 @@ echo "Grandine: Stopping Client..."
 
 sudo systemctl stop grandine
 
-# Stop Geth
-
-echo "Grandine: Stopping Geth..."
-
-sudo systemctl stop geth
 # (we stop geth as Lodestar will use its own geth docker)
 
 # Export Slashing protection
-
+rm /home/ethereum/grandine_logs/slashing_protection.json
 echo "Exporting Slashing Protection..."
 
-./grandine-0.2.0_beta3_arm64 --network kiln interchange export /home/ethereum/grandine_logs/slashing_protection.json | tee -a slashing_export.log
+./grandine-0.2.0_beta3_arm64 --network kiln interchange export /home/ethereum/grandine_logs/slashing_protection.json
 sleep $TWO_EPOCHS
 # -----------------------------------------------------------------------------
 
@@ -265,33 +263,25 @@ echo "Lodestar"
 
 echo "Lodestar: Moving to Lodestar folder..."
 
-cd /home/ethereum/lodestar_logs/lodestar/kiln/devnets
-
 # Run Lodestar Beacon Node
 
 echo "Lodestar: Running whole setup without validators..."
 
-sudo systemctl start lodestar_noval
+sudo systemctl start lodestar
 
 # Import Slashing protection
 
-echo "Lodestar: Copying slashing db into Lodestar Docker folder..."
-
-cp /home/ethereum//grandine_logs/slashing_protection.json /home/ethereum/lodestar_logs/lodestar/kiln/devnets/kiln-data/
-
 echo "Lodestar: Importing Slashing protection..."
 
-sudo docker run --rm --name kiln-lodestar_val --network host -v /home/ethereum/lodestar_logs/lodestar/kiln/devnets/kiln-data:/data -v /home/ethereum/lodestar_logs/lodestar/kiln/devnets/kiln-data/kiln:/config chainsafe/lodestar:arm64 validator slashing-protection import --network kiln --file /data/slashing_protection.json --rootDir /data/lodestar | tee -a slashing_import.log
+# /home/ethereum/lodestar_logs/lodestar/lodestar validator slashing-protection import --network kiln --file /home/ethereum/grandine_logs/slashing_protection.json --rootDir /home/ethereum/lodestar_logs/lodestar-beacondata/
+sleep 100
 
+su - ethereum -c "/home/ethereum/lodestar_logs/lodestar/import_slashing.sh"
 # Importing validators (already imported)
 
-# Stopping beacon node
+# Running validators
 
-sudo systemctl stop lodestar_noval
-
-# Running whole setup
-
-sudo systemctl start lodestar
+sudo systemctl start lodestar_val
 
 echo "Lodestar: Let the client run..."
 
@@ -299,22 +289,18 @@ sleep $SLEEP_TIME
 
 # Stop the Lodestar setup
 
-echo "Lodestar: Stopping whole setup..."
+echo "Lodestar: Stopping validators..."
 
-sudo systemctl stop lodestar
-
-# Launch Lodestar without validators
-
-echo "Lodestar: Running without validators..."
-
-sudo systemctl start lodestar_noval
+sudo systemctl stop lodestar_val
 
 # Export Slashing Protection
 
 echo "Lodestar: Exporting Slashing protection..."
 
-sudo docker run --rm --name kiln-lodestar_val --network host -v /home/ethereum/lodestar_logs/lodestar/kiln/devnets/kiln-data:/data -v /home/ethereum/lodestar_logs/lodestar/kiln/devnets/kiln-data/kiln:/config chainsafe/lodestar:arm64 validator slashing-protection export --network kiln --file /data/slashing_protection.json --rootDir /data/lodestar | tee -a slashing_import.log
+rm /home/ethereum/lodestar_logs/slashing_protection.json
 
-sudo systemctl stop lodestar_noval
-
-sudo systemctl start geth
+# /home/ethereum/lodestar_logs/lodestar/lodestar validator slashing-protection export --network kiln --file /home/ethereum/lodestar_logs/slashing_protection.json --rootDir /home/ethereum/lodestar_logs/lodestar-beacondata/
+su - ethereum -c "/home/ethereum/lodestar_logs/lodestar/export_slashing.sh"
+echo "Lodestar: Stopping Beacon Node..."
+sudo systemctl stop lodestar
+done

--- a/validator_management/lodestar.service
+++ b/validator_management/lodestar.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Lodestar Setup
+After=network.target
+
+[Service]
+ExecStart=/home/ethereum/lodestar_logs/lodestar/launch_lodestar.sh
+WorkingDirectory=/home/ethereum/lodestar_logs/lodestar/
+Restart=always
+User=ethereum
+StandardOutput=append:/home/ethereum/lodestar_logs/lodestar_std.log
+StandardError=append:/home/ethereum/lodestar_logs/lodestar_err.log
+
+
+[Install]
+WantedBy=multi-user.target

--- a/validator_management/lodestar_export_slashing.sh
+++ b/validator_management/lodestar_export_slashing.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /home/ethereum/lodestar_logs/lodestar
+source /home/ethereum/.bashrc
+/home/ethereum/lodestar_logs/lodestar/lodestar validator slashing-protection export --network kiln --file /home/ethereum/lodestar_logs/slashing_protection.json --rootDir /home/ethereum/lodestar_logs/lodestar-beacondata/

--- a/validator_management/lodestar_import_slashing.sh
+++ b/validator_management/lodestar_import_slashing.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /home/ethereum/lodestar_logs/lodestar
+source /home/ethereum/.bashrc
+/home/ethereum/lodestar_logs/lodestar/lodestar validator slashing-protection import --network kiln --file /home/ethereum/grandine_logs/slashing_protection.json --rootDir /home/ethereum/lodestar_logs/lodestar-beacondata/

--- a/validator_management/lodestar_launch_bn.sh
+++ b/validator_management/lodestar_launch_bn.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /home/ethereum/lodestar_logs/lodestar
+source /home/ethereum/.bashrc
+./lodestar beacon --rootDir="../lodestar-beacondata" --network kiln --eth1.enabled=true --execution.urls="http://127.0.0.1:8551" --network.connectToDiscv5Bootnodes --network.discv5.enabled=true --jwt-secret /etc/ethereum/kiln/jwtsecret --network.discv5.bootEnrs="enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk" --weakSubjectivitySyncLatest --weakSubjectivityServerUrl https://lodestar-kiln.chainsafe.io

--- a/validator_management/lodestar_launch_val.sh
+++ b/validator_management/lodestar_launch_val.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /home/ethereum/lodestar_logs/lodestar
+source /home/ethereum/.bashrc
+./lodestar validator --network kiln --rootDir ../lodestar-beacondata

--- a/validator_management/lodestar_val.service
+++ b/validator_management/lodestar_val.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Lodestar Setup
+After=network.target
+
+[Service]
+ExecStart=/home/ethereum/lodestar_logs/lodestar/launch_val.sh 
+WorkingDirectory=/home/ethereum/lodestar_logs/lodestar/
+Restart=always
+User=ethereum
+StandardOutput=append:/home/ethereum/lodestar_logs/lodestar_val_std.log
+StandardError=append:/home/ethereum/lodestar_logs/lodestar_val_err.log
+
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Description
This branch is meant for carrying out a validator key management experiment

# Motivation
After performing the Eth2 CL clients analysis, we want to analyze how easy it is to transition the validator from one client to another. In order to do so, we will be using a Raspberry PI in the Kiln network.

# TODOs

- Manually import and export slashing protection from one client into another
- Create a script to do this automatically
- Create a README file explaining the process